### PR TITLE
Add Flask scaffolding and templates for story blog UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,57 @@
+from flask import Flask, render_template
+
+app = Flask(__name__)
+
+
+@app.route("/")
+def home():
+    return render_template("home.html")
+
+
+@app.route("/explore")
+def explore():
+    creators = [
+        {"name": "Ava Sol", "initials": "AS", "bio": "Sci-fi dreamer · 12 new prompts this week"},
+        {"name": "Noah Rivers", "initials": "NR", "bio": "Mythology enthusiast · Collaboration open"},
+        {"name": "Lena Coast", "initials": "LC", "bio": "Writes micro essays · #30DayChallenge"},
+        {"name": "Kai Bloom", "initials": "KB", "bio": "Illustrated tales · Accepting commissions"},
+    ]
+    return render_template("explore.html", creators=creators)
+
+
+@app.route("/profile")
+def profile():
+    profile_data = {
+        "name": "Nova Scribbles",
+        "initials": "NS",
+        "bio": "Story architect · Visual storyteller",
+        "about": "I create interactive fiction experiences inspired by urban legends and everyday magic.",
+        "story_count": 13,
+        "followers": 482,
+        "drafts": 7,
+    }
+    return render_template("profile.html", profile=profile_data)
+
+
+@app.route("/create")
+def create_post():
+    return render_template("create_post.html")
+
+
+@app.route("/login", methods=["GET", "POST"])
+def login():
+    return render_template("login.html")
+
+
+@app.route("/signup", methods=["GET", "POST"])
+def signup():
+    return render_template("signup.html")
+
+
+@app.route("/help")
+def faq():
+    return render_template("faq.html")
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -1,0 +1,485 @@
+:root {
+    color-scheme: light;
+    --bg: #f7f8fb;
+    --surface: #ffffff;
+    --surface-alt: #f0f3ff;
+    --primary: #2b6ef2;
+    --primary-dark: #1e4eb0;
+    --accent: #ffb650;
+    --text: #161928;
+    --muted: #6d7385;
+    --border: #d9dfec;
+    --shadow: 0 15px 35px rgba(29, 43, 78, 0.08);
+    font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    background-color: var(--bg);
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    color: var(--text);
+    background-color: var(--bg);
+}
+
+.app-shell {
+    min-height: 100vh;
+    display: grid;
+    grid-template-columns: 80px 1fr;
+    background: var(--bg);
+}
+
+.sidebar {
+    background: #0f4fd7;
+    color: #fff;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 24px 0;
+    gap: 24px;
+}
+
+.sidebar__logo {
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.sidebar__nav {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.sidebar__item {
+    width: 48px;
+    height: 48px;
+    border-radius: 16px;
+    display: grid;
+    place-items: center;
+    background: rgba(255, 255, 255, 0.12);
+    color: inherit;
+    text-decoration: none;
+    transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.sidebar__item:hover,
+.sidebar__item:focus-visible {
+    transform: translateY(-3px);
+    background: rgba(255, 255, 255, 0.22);
+}
+
+.sidebar__icon {
+    font-size: 1.4rem;
+}
+
+.main {
+    background: var(--bg);
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+}
+
+.topbar {
+    background: var(--surface);
+    border-bottom: 1px solid var(--border);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 24px 40px;
+}
+
+.topbar__logo {
+    font-weight: 700;
+    font-size: 1.2rem;
+    letter-spacing: 0.02em;
+}
+
+.content {
+    padding: 40px;
+    flex: 1;
+}
+
+.card-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 24px;
+}
+
+.story-card {
+    background: var(--surface);
+    border-radius: 24px;
+    padding: 28px;
+    box-shadow: var(--shadow);
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.story-card__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.story-card__title {
+    font-size: 1.4rem;
+    margin: 0;
+}
+
+.story-card__tag {
+    background: var(--surface-alt);
+    color: var(--primary);
+    border-radius: 20px;
+    padding: 6px 14px;
+    font-size: 0.85rem;
+    font-weight: 600;
+}
+
+.story-card__tag--green {
+    color: #2b9f4f;
+    background: rgba(43, 159, 79, 0.12);
+}
+
+.story-card__excerpt {
+    margin: 0;
+    color: var(--muted);
+}
+
+.story-card__footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 0.85rem;
+    color: var(--muted);
+}
+
+.story-card__link {
+    text-decoration: none;
+    color: var(--primary);
+    font-weight: 600;
+}
+
+.search-bar {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    background: var(--surface-alt);
+    padding: 8px 12px;
+    border-radius: 16px;
+}
+
+.search-bar input {
+    border: none;
+    background: transparent;
+    width: 320px;
+    font-size: 0.95rem;
+    outline: none;
+}
+
+.search-bar button {
+    border: none;
+    background: var(--primary);
+    color: #fff;
+    border-radius: 12px;
+    padding: 8px 16px;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.creator-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.creator-list__item {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    background: var(--surface);
+    padding: 20px;
+    border-radius: 20px;
+    box-shadow: var(--shadow);
+}
+
+.avatar {
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    display: grid;
+    place-items: center;
+    background: var(--primary);
+    color: #fff;
+    font-weight: 600;
+}
+
+.creator-list__meta {
+    flex: 1;
+}
+
+.creator-list__name {
+    display: block;
+    font-weight: 600;
+}
+
+.creator-list__desc {
+    color: var(--muted);
+    font-size: 0.9rem;
+}
+
+.creator-list__follow {
+    border: none;
+    background: var(--surface-alt);
+    color: var(--primary);
+    border-radius: 12px;
+    padding: 10px 18px;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.profile {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.profile__header {
+    display: flex;
+    gap: 20px;
+    align-items: center;
+}
+
+.profile__avatar {
+    width: 96px;
+    height: 96px;
+    border-radius: 24px;
+    background: var(--primary);
+    color: #fff;
+    display: grid;
+    place-items: center;
+    font-size: 2rem;
+    font-weight: 700;
+}
+
+.profile__name {
+    margin: 0;
+    font-size: 2rem;
+}
+
+.profile__bio {
+    margin: 4px 0 0;
+    color: var(--muted);
+}
+
+.profile__actions {
+    display: flex;
+    gap: 12px;
+}
+
+.profile__about,
+.profile__stats {
+    background: var(--surface);
+    padding: 28px;
+    border-radius: 24px;
+    box-shadow: var(--shadow);
+}
+
+.profile__stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 16px;
+}
+
+.stat-card {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.stat-card__number {
+    font-size: 2rem;
+    font-weight: 700;
+}
+
+.stat-card__label {
+    color: var(--muted);
+}
+
+.btn {
+    background: var(--primary);
+    color: #fff;
+    border: none;
+    border-radius: 14px;
+    padding: 10px 20px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.2s ease;
+}
+
+.btn:hover,
+.btn:focus-visible {
+    background: var(--primary-dark);
+}
+
+.btn--ghost {
+    background: rgba(43, 110, 242, 0.12);
+    color: var(--primary);
+}
+
+.btn--ghost:hover,
+.btn--ghost:focus-visible {
+    background: rgba(43, 110, 242, 0.2);
+}
+
+.btn--danger {
+    background: rgba(238, 68, 68, 0.14);
+    color: #d33535;
+}
+
+.btn--danger:hover,
+.btn--danger:focus-visible {
+    background: rgba(238, 68, 68, 0.24);
+}
+
+.composer {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    background: var(--surface);
+    padding: 32px;
+    border-radius: 28px;
+    box-shadow: var(--shadow);
+}
+
+.composer__editor textarea {
+    width: 100%;
+    min-height: 320px;
+    border-radius: 20px;
+    border: 1px solid var(--border);
+    padding: 20px;
+    font-family: inherit;
+    font-size: 1rem;
+    resize: vertical;
+}
+
+.composer__footer {
+    display: flex;
+    gap: 12px;
+    justify-content: flex-end;
+}
+
+.auth-card {
+    max-width: 420px;
+    margin: 0 auto;
+    background: var(--surface);
+    padding: 40px;
+    border-radius: 28px;
+    box-shadow: var(--shadow);
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+    text-align: center;
+}
+
+.auth-card__title {
+    margin: 0;
+    font-size: 2rem;
+}
+
+.auth-card__subtitle {
+    margin: 0;
+    color: var(--muted);
+}
+
+.form {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    text-align: left;
+}
+
+.form__field {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    font-weight: 500;
+}
+
+.form__field input,
+.form__field textarea {
+    border-radius: 14px;
+    border: 1px solid var(--border);
+    padding: 12px 16px;
+    font-size: 1rem;
+    font-family: inherit;
+}
+
+.form__submit {
+    width: 100%;
+    margin-top: 8px;
+}
+
+.form__alt {
+    text-align: center;
+    color: var(--primary);
+    text-decoration: none;
+    font-weight: 600;
+}
+
+.faq {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+    max-width: 640px;
+}
+
+.faq__item {
+    background: var(--surface);
+    padding: 24px;
+    border-radius: 22px;
+    box-shadow: var(--shadow);
+}
+
+.faq__item h2 {
+    margin-top: 0;
+}
+
+@media (max-width: 900px) {
+    .app-shell {
+        grid-template-columns: 72px 1fr;
+    }
+
+    .topbar {
+        padding: 20px;
+    }
+
+    .content {
+        padding: 24px;
+    }
+}
+
+@media (max-width: 600px) {
+    .app-shell {
+        grid-template-columns: 1fr;
+    }
+
+    .sidebar {
+        flex-direction: row;
+        justify-content: space-between;
+        padding: 12px 20px;
+    }
+
+    .sidebar__nav {
+        flex-direction: row;
+    }
+
+    .main {
+        min-height: auto;
+    }
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}Story Blog{% endblock %}</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/app.css') }}">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div class="app-shell">
+        <aside class="sidebar">
+            <div class="sidebar__logo">StoryBlog</div>
+            <nav class="sidebar__nav">
+                <a href="{{ url_for('home') }}" class="sidebar__item" aria-label="Dashboard">
+                    <span class="sidebar__icon">🏠</span>
+                </a>
+                <a href="{{ url_for('explore') }}" class="sidebar__item" aria-label="Trending">
+                    <span class="sidebar__icon">🔥</span>
+                </a>
+                <a href="{{ url_for('profile') }}" class="sidebar__item" aria-label="Profile">
+                    <span class="sidebar__icon">👤</span>
+                </a>
+                <a href="{{ url_for('create_post') }}" class="sidebar__item" aria-label="Create">
+                    <span class="sidebar__icon">✏️</span>
+                </a>
+                <a href="{{ url_for('faq') }}" class="sidebar__item" aria-label="Help">
+                    <span class="sidebar__icon">❔</span>
+                </a>
+            </nav>
+        </aside>
+        <main class="main">
+            <header class="topbar">
+                <div class="topbar__logo">Story Blog</div>
+                {% block top_actions %}{% endblock %}
+            </header>
+            <section class="content">
+                {% block content %}{% endblock %}
+            </section>
+        </main>
+    </div>
+</body>
+</html>

--- a/templates/create_post.html
+++ b/templates/create_post.html
@@ -1,0 +1,18 @@
+{% extends 'base.html' %}
+{% block title %}Story Blog · Create{% endblock %}
+{% block content %}
+<div class="composer">
+    <header class="composer__header">
+        <h1>Create post</h1>
+        <span class="composer__tip">Use the canvas below to explore your story ideas.</span>
+    </header>
+    <div class="composer__editor">
+        <textarea placeholder="Start drafting your next story…"></textarea>
+    </div>
+    <footer class="composer__footer">
+        <button class="btn btn--ghost">Save draft</button>
+        <button class="btn">Publish</button>
+        <button class="btn btn--danger">Delete</button>
+    </footer>
+</div>
+{% endblock %}

--- a/templates/explore.html
+++ b/templates/explore.html
@@ -1,0 +1,22 @@
+{% extends 'base.html' %}
+{% block title %}Story Blog · Explore{% endblock %}
+{% block top_actions %}
+<form class="search-bar">
+    <input type="search" name="q" placeholder="Explore stories, creators, and prompts…" aria-label="Explore" />
+    <button type="submit">Search</button>
+</form>
+{% endblock %}
+{% block content %}
+<ul class="creator-list">
+    {% for creator in creators %}
+    <li class="creator-list__item">
+        <div class="avatar">{{ creator.initials }}</div>
+        <div class="creator-list__meta">
+            <span class="creator-list__name">{{ creator.name }}</span>
+            <span class="creator-list__desc">{{ creator.bio }}</span>
+        </div>
+        <button class="creator-list__follow">Follow</button>
+    </li>
+    {% endfor %}
+</ul>
+{% endblock %}

--- a/templates/faq.html
+++ b/templates/faq.html
@@ -1,0 +1,20 @@
+{% extends 'base.html' %}
+{% block title %}Story Blog · Help{% endblock %}
+{% block content %}
+<div class="faq">
+    <h1>Need help?</h1>
+    <p>Here are some quick answers to keep your storytelling flow uninterrupted.</p>
+    <div class="faq__item">
+        <h2>How do I start a new story?</h2>
+        <p>Select the pencil icon in the sidebar or click “New Post” on your profile page to open the editor.</p>
+    </div>
+    <div class="faq__item">
+        <h2>Can I collaborate with others?</h2>
+        <p>Collaboration tools are coming soon. For now, share drafts by exporting and inviting feedback.</p>
+    </div>
+    <div class="faq__item">
+        <h2>Where are my drafts saved?</h2>
+        <p>Drafts are saved to your workspace automatically. Visit the Drafts tab on your profile to view them.</p>
+    </div>
+</div>
+{% endblock %}

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,0 +1,28 @@
+{% extends 'base.html' %}
+{% block title %}Story Blog · Dashboard{% endblock %}
+{% block content %}
+<div class="card-grid">
+    <article class="story-card">
+        <header class="story-card__header">
+            <h2 class="story-card__title">Day #1</h2>
+            <span class="story-card__tag">Pop-up</span>
+        </header>
+        <p class="story-card__excerpt">First adventures in crafting immersive storytelling experiences with our new editor.</p>
+        <footer class="story-card__footer">
+            <span class="story-card__meta">Updated 2 hours ago</span>
+            <a class="story-card__link" href="#">Open draft →</a>
+        </footer>
+    </article>
+    <article class="story-card">
+        <header class="story-card__header">
+            <h2 class="story-card__title">Day #2</h2>
+            <span class="story-card__tag story-card__tag--green">Pop-up</span>
+        </header>
+        <p class="story-card__excerpt">Exploring the forests of inspiration—discover the prompts that sparked today's stories.</p>
+        <footer class="story-card__footer">
+            <span class="story-card__meta">Updated yesterday</span>
+            <a class="story-card__link" href="#">Open draft →</a>
+        </footer>
+    </article>
+</div>
+{% endblock %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,20 @@
+{% extends 'base.html' %}
+{% block title %}Story Blog · Login{% endblock %}
+{% block content %}
+<div class="auth-card">
+    <h1 class="auth-card__title">Welcome back</h1>
+    <p class="auth-card__subtitle">Sign in to continue crafting your stories.</p>
+    <form class="form" method="post">
+        <label class="form__field">
+            <span>Username</span>
+            <input type="text" name="username" placeholder="Username" required>
+        </label>
+        <label class="form__field">
+            <span>Password</span>
+            <input type="password" name="password" placeholder="Password" required>
+        </label>
+        <button class="btn form__submit" type="submit">Submit</button>
+        <a class="form__alt" href="{{ url_for('signup') }}">Need an account? Sign up</a>
+    </form>
+</div>
+{% endblock %}

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -1,0 +1,36 @@
+{% extends 'base.html' %}
+{% block title %}Story Blog · Profile{% endblock %}
+{% block content %}
+<div class="profile">
+    <div class="profile__header">
+        <div class="profile__avatar">{{ profile.initials }}</div>
+        <div>
+            <h1 class="profile__name">{{ profile.name }}</h1>
+            <p class="profile__bio">{{ profile.bio }}</p>
+        </div>
+    </div>
+    <div class="profile__actions">
+        <a class="btn" href="{{ url_for('create_post') }}">New Post</a>
+        <button class="btn btn--ghost">Drafts</button>
+        <button class="btn btn--ghost">Edit profile</button>
+    </div>
+    <section class="profile__about">
+        <h2>About me</h2>
+        <p>{{ profile.about }}</p>
+    </section>
+    <section class="profile__stats">
+        <div class="stat-card">
+            <span class="stat-card__number">{{ profile.story_count }}</span>
+            <span class="stat-card__label">Stories published</span>
+        </div>
+        <div class="stat-card">
+            <span class="stat-card__number">{{ profile.followers }}</span>
+            <span class="stat-card__label">Followers</span>
+        </div>
+        <div class="stat-card">
+            <span class="stat-card__number">{{ profile.drafts }}</span>
+            <span class="stat-card__label">Drafts</span>
+        </div>
+    </section>
+</div>
+{% endblock %}

--- a/templates/signup.html
+++ b/templates/signup.html
@@ -1,0 +1,35 @@
+{% extends 'base.html' %}
+{% block title %}Story Blog · Sign up{% endblock %}
+{% block content %}
+<div class="auth-card">
+    <h1 class="auth-card__title">Create your account</h1>
+    <p class="auth-card__subtitle">Join the Story Blog community.</p>
+    <form class="form" method="post">
+        <label class="form__field">
+            <span>Full name</span>
+            <input type="text" name="name" placeholder="Name" required>
+        </label>
+        <label class="form__field">
+            <span>Username</span>
+            <input type="text" name="username" placeholder="Username" required>
+        </label>
+        <label class="form__field">
+            <span>Email</span>
+            <input type="email" name="email" placeholder="Email" required>
+        </label>
+        <label class="form__field">
+            <span>Phone number <small>(optional)</small></span>
+            <input type="tel" name="phone" placeholder="Phone number">
+        </label>
+        <label class="form__field">
+            <span>Password</span>
+            <input type="password" name="password" placeholder="Password" required>
+        </label>
+        <label class="form__field">
+            <span>Confirm password</span>
+            <input type="password" name="confirm_password" placeholder="Confirm password" required>
+        </label>
+        <button class="btn form__submit" type="submit">Sign up</button>
+    </form>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a Flask application with routes for dashboard, explore, profile, compose, auth, and help views
- build base layout and themed templates that mirror the provided sketches
- introduce shared modern styling for the sidebar workspace and content cards

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68fd34480f34832488e3d7bb1df5835c